### PR TITLE
[Chore] Issue 연동용 Workflow 추가: Edit

### DIFF
--- a/.github/workflows/issue_edit.jira.yaml
+++ b/.github/workflows/issue_edit.jira.yaml
@@ -1,0 +1,75 @@
+name: Sync Jira Issue - Edit
+on:
+  issues:
+    types:
+      - edited
+jobs:
+  create-issue:
+    name: Open Jira Issue
+    runs-on: ubuntu-latest
+    steps:
+      - name: Login to Jira
+        uses: atlassian/gajira-login@v3
+        env:
+          JIRA_BASE_URL: ${{ secrets.JIRA_BASE_URL }}
+          JIRA_API_TOKEN: ${{ secrets.JIRA_API_TOKEN }}
+          JIRA_USER_EMAIL: ${{ secrets.JIRA_USER_EMAIL }}
+
+      - name: Extract Jira issue key from GitHub issue title
+        id: extract-key
+        run: |
+          ISSUE_TITLE="${{ github.event.issue.title }}"
+          JIRA_KEY=$(echo "$ISSUE_TITLE" | grep -oE '[A-Z]+-[0-9]+')
+          echo "JIRA_KEY=$JIRA_KEY" >> $GITHUB_ENV
+
+      - name: Checkout main code
+        uses: actions/checkout@v4
+        with:
+          ref: publish
+
+      - name: Issue Parser
+        uses: stefanbuck/github-issue-praser@v3
+        id: issue-parser
+        with:
+          template-path: .github/ISSUE_TEMPLATE/custom_template.yml
+
+      - name: Log Issue Parser
+        run: |
+          echo '${{ steps.issue-parser.outputs.issueparser_parentKey }}'
+          echo '${{ steps.issue-parser.outputs.__ticket_number }}'
+          echo '${{ steps.issue-parser.outputs.jsonString }}'
+
+      - name: Convert markdown to Jira Syntax
+        uses: peter-evans/jira2md@v1
+        id: md2jira
+        with:
+          input-text: |
+            ### Github Issue Link
+            - ${{ github.event.issue.html_url }}
+
+            ${{ github.event.issue.body }}
+          mode: md2jira
+
+      - name: Update Issue
+        id: create
+        uses: Dash-ajou/gajira-edit@v1.0.0
+        with:
+          issue: ${{ env.JIRA_KEY }}
+          project: DASH
+          issuetype: Task
+          summary: '${{ github.event.issue.title }}'
+          description: '${{ steps.md2jira.outputs.output-text }}'
+          fields: |
+            {
+              "parent": {
+                "key": "${{ steps.issue-parser.outputs.issueparser_parentKey }}"
+              }
+            }
+
+      - name: Add comment with Jira issue link
+        uses: actions-cool/issues-helper@v3
+        with:
+          actions: 'create-comment'
+          token: ${{ secrets.GITHUB_TOKEN }}
+          issue-number: ${{ github.event.issue.number }}
+          body: 'Jira Issue Updated: [${{ env.JIRA_KEY }}](${{ secrets.JIRA_BASE_URL }}/browse/${{ env.JIRA_KEY }})'


### PR DESCRIPTION
## 🌲 작업한 브랜치
- DASH-14/sync/jira

## ❗참고사항
- PR 복잡도 간소화를 위해 sync, hotfix prefix 브랜치에 한하여 publish로의 merge를 허용

## 📚 작업한 내용
- Issue 연동용 workflow 추가: edit
- 신규 repo 작성 및 연동: [Dash-ajou/gajira-edit](https://www.github.com/Dash-ajou/gajira-edit)

## ❗이슈 사항


## 🤔 궁금한 점
