### PR TITLE
[BE] Auth API, 계정 관리 API 기능 추가

### DIFF
--- a/src/main/java/io/saim/dash/account/auth/controller/LogoutController.java
+++ b/src/main/java/io/saim/dash/account/auth/controller/LogoutController.java
@@ -1,0 +1,46 @@
+package io.saim.dash.account.auth.controller;
+
+import io.saim.dash.account.auth.service.LogoutService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.Collections;
+import java.util.Map;
+
+@RestController
+@RequestMapping("/auth")
+@RequiredArgsConstructor
+public class LogoutController {
+
+	private final LogoutService logoutService;
+
+	@PostMapping("/logout")
+	public ResponseEntity<?> logout(@RequestHeader(value = "Authorization", required = false) String sessionId) {
+		System.out.println("🔹 Received sessionId: " + sessionId);
+		System.out.println("🔹 logoutService is null? " + (logoutService == null));
+
+		if (sessionId == null || sessionId.isBlank()) {
+			return ResponseEntity.badRequest().body(Map.of(
+				"status", "failure",
+				"message", "세션 ID가 누락되었습니다."
+			));
+		}
+
+		boolean isLoggedOut = logoutService.invalidateSession(sessionId);
+		System.out.println("🔹 Logout result: " + isLoggedOut);
+
+		if (isLoggedOut) {
+			return ResponseEntity.ok(Map.of(
+				"status", "SUCCEED",
+				"message", "로그아웃 되었습니다.",
+				"data", Collections.emptyMap()
+			));
+		} else {
+			return ResponseEntity.status(400).body(Map.of(
+				"status", "failure",
+				"message", "유효하지 않은 세션 ID입니다."
+			));
+		}
+	}
+}

--- a/src/main/java/io/saim/dash/account/auth/controller/PasswordResetController.java
+++ b/src/main/java/io/saim/dash/account/auth/controller/PasswordResetController.java
@@ -6,15 +6,22 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import io.saim.dash.account.auth.dto.PasswordResetRequestDTO;
+import io.saim.dash.account.auth.dto.PasswordResetResponseDTO;
 import io.saim.dash.account.auth.dto.PhoneVerificationCheckDTO;
 import io.saim.dash.account.auth.service.PhoneVerificationService;
+import io.saim.dash.account.auth.service.PasswordResetService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
 
 @RestController
 @RequestMapping("/auth/password-reset")
+@RequiredArgsConstructor
 public class PasswordResetController {
 
 	@Autowired
 	private PhoneVerificationService phoneVerificationService;
+	private final PasswordResetService passwordResetService;
 
 	//비밀번호 재설정 인증 요청
 	@PostMapping("/request")
@@ -50,5 +57,11 @@ public class PasswordResetController {
 				"message", "Invalid or expired verification code."
 			));
 		}
+	}
+
+	@PostMapping("/complete")
+	public ResponseEntity<PasswordResetResponseDTO> resetPassword(@Valid @RequestBody PasswordResetRequestDTO requestDTO) {
+		PasswordResetResponseDTO response = passwordResetService.resetPassword(requestDTO);
+		return ResponseEntity.ok(response);
 	}
 }

--- a/src/main/java/io/saim/dash/account/auth/dto/LoginRequestDTO.java
+++ b/src/main/java/io/saim/dash/account/auth/dto/LoginRequestDTO.java
@@ -13,10 +13,10 @@ public class LoginRequestDTO {
 
 	@NotBlank(message = "전화번호는 필수 입력값입니다.")
 	@Pattern(regexp = "^01[0-9]-\\d{3,4}-\\d{4}$", message = "올바른 전화번호 형식이 아닙니다.")
-	@JsonProperty("user_phone")  // ✅ JSON 요청의 "user_phone"을 generalPhone에 매핑
+	@JsonProperty("user_phone")
 	private String generalPhone;
 
 	@NotBlank(message = "비밀번호는 필수입니다.")
-	@JsonProperty("user_password")  // ✅ JSON 요청의 "user_password"을 userPassword에 매핑
+	@JsonProperty("user_password")
 	private String userPassword;
 }

--- a/src/main/java/io/saim/dash/account/auth/dto/LoginRequestDTO.java
+++ b/src/main/java/io/saim/dash/account/auth/dto/LoginRequestDTO.java
@@ -1,9 +1,10 @@
 package io.saim.dash.account.auth.dto;
 
+import io.saim.dash.common.constants.ValidationMessages;
+import io.saim.dash.common.constants.ValidationPatterns;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
 import com.fasterxml.jackson.annotation.JsonProperty;
-
 import lombok.Getter;
 import lombok.Setter;
 
@@ -11,12 +12,12 @@ import lombok.Setter;
 @Setter
 public class LoginRequestDTO {
 
-	@NotBlank(message = "전화번호는 필수 입력값입니다.")
-	@Pattern(regexp = "^01[0-9]-\\d{3,4}-\\d{4}$", message = "올바른 전화번호 형식이 아닙니다.")
+	@NotBlank(message = ValidationMessages.PHONE_REQUIRED)
+	@Pattern(regexp = ValidationPatterns.PHONE_REGEX, message = ValidationMessages.PHONE_INVALID_FORMAT)
 	@JsonProperty("user_phone")
 	private String generalPhone;
 
-	@NotBlank(message = "비밀번호는 필수입니다.")
+	@NotBlank(message = ValidationMessages.PASSWORD_REQUIRED)
 	@JsonProperty("user_password")
 	private String userPassword;
 }

--- a/src/main/java/io/saim/dash/account/auth/dto/PasswordResetRequestDTO.java
+++ b/src/main/java/io/saim/dash/account/auth/dto/PasswordResetRequestDTO.java
@@ -1,4 +1,4 @@
-package io.saim.dash.account.general.dto;
+package io.saim.dash.account.auth.dto;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.validation.constraints.NotBlank;
@@ -9,20 +9,20 @@ import lombok.Setter;
 
 @Getter
 @Setter
-public class GeneralPasswordRequestDTO {
+public class PasswordResetRequestDTO {
 
-	@NotBlank(message = "사용자 ID는 필수입니다.")
-	@JsonProperty("general_id")
-	private Long generalId;
+	@NotBlank(message = "전화번호는 필수입니다.")
+	@JsonProperty("user_phone")
+	private String userPhone;
 
-	@NotBlank(message = "비밀번호는 필수입니다.")
+	@NotBlank(message = "새 비밀번호는 필수입니다.")
 	@Size(min = 8, max = 20, message = "비밀번호는 8~20자로 입력해야 합니다.")
 	@Pattern(regexp = "^(?=.*[A-Z])(?=.*[a-z])(?=.*\\d)(?=.*[@$!%*?&])[A-Za-z\\d@$!%*?&]{8,20}$",
 		message = "비밀번호는 영문 대소문자, 숫자, 특수문자를 포함해야 합니다.")
-	@JsonProperty("password")
-	private String password;
+	@JsonProperty("new_password")
+	private String newPassword;
 
 	@NotBlank(message = "비밀번호 확인은 필수입니다.")
-	@JsonProperty("password_confirm")
-	private String passwordConfirm;
+	@JsonProperty("new_password_confirm")
+	private String newPasswordConfirm;
 }

--- a/src/main/java/io/saim/dash/account/auth/dto/PasswordResetResponseDTO.java
+++ b/src/main/java/io/saim/dash/account/auth/dto/PasswordResetResponseDTO.java
@@ -1,0 +1,13 @@
+package io.saim.dash.account.auth.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+public class PasswordResetResponseDTO {
+	private String status;
+	private String message;
+}

--- a/src/main/java/io/saim/dash/account/auth/model/PhoneVerification.java
+++ b/src/main/java/io/saim/dash/account/auth/model/PhoneVerification.java
@@ -14,16 +14,16 @@ import jakarta.persistence.Table;
 public class PhoneVerification {
 
 	@Id
-	@GeneratedValue(strategy = GenerationType.IDENTITY) // 자동 증가 ID
+	@GeneratedValue(strategy = GenerationType.IDENTITY) //자동 증가 ID
 	private Long id;
 
-	@Column(nullable = false, unique = true) // 전화번호는 필수이며 중복 불가
+	@Column(nullable = false, unique = true) //전화번호는 필수이며 중복 불가
 	private String userPhone;
 
-	@Column(nullable = false) // 생성된 인증 코드
+	@Column(nullable = false) //생성된 인증 코드
 	private String userVerifyCode;
 
-	@Column(nullable = false) // 인증 코드 만료 시간
+	@Column(nullable = false) //인증 코드 만료 시간
 	private LocalDateTime expiresIn;
 
 	@Column(nullable = false)

--- a/src/main/java/io/saim/dash/account/auth/service/LoginService.java
+++ b/src/main/java/io/saim/dash/account/auth/service/LoginService.java
@@ -6,7 +6,6 @@ import io.saim.dash.account.general.model.SignupName;
 import io.saim.dash.account.general.repository.GeneralPasswordRepository;
 import io.saim.dash.account.general.repository.SignupNameRepository;
 import lombok.RequiredArgsConstructor;
-
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Service;
 import java.util.UUID;
@@ -24,12 +23,14 @@ public class LoginService {
 		SignupName user = signupNameRepository.findByGeneralPhone(generalPhone)
 			.orElseThrow(() -> new IllegalArgumentException("등록되지 않은 전화번호입니다."));
 
-		//비밀번호 조회 (해당 사용자 ID를 기반으로)
+		//가장 최근 비밀번호 가져오기 (최신 createdAt 기준 정렬)
 		Password userPassword = passwordRepository.findByUser(user)
+			.stream()
+			.max((p1, p2) -> p1.getCreatedAt().compareTo(p2.getCreatedAt())) //최신 비밀번호 가져오기
 			.orElseThrow(() -> new IllegalArgumentException("비밀번호가 설정되지 않았습니다."));
 
 		//비밀번호 비교 (비교 전 `trim()` 적용)
-		String inputPassword = rawPassword.trim();  // 🚀 공백 문제 방지
+		String inputPassword = rawPassword.trim();
 		String storedPassword = userPassword.getHashedPassword();
 
 		System.out.println("입력된 비밀번호: " + inputPassword);
@@ -50,11 +51,12 @@ public class LoginService {
 					user.getGeneralPhone(),
 					user.getGeneralType()
 				),
-				generateSessionId()
+				generateSessionId() //세션 ID 생성
 			)
 		);
 	}
 
+	//세션 ID 생성 로직
 	private String generateSessionId() {
 		return UUID.randomUUID().toString();
 	}

--- a/src/main/java/io/saim/dash/account/auth/service/LoginService.java
+++ b/src/main/java/io/saim/dash/account/auth/service/LoginService.java
@@ -1,6 +1,7 @@
 package io.saim.dash.account.auth.service;
 
 import io.saim.dash.account.auth.dto.LoginResponseDTO;
+import io.saim.dash.account.auth.session.SessionManager;
 import io.saim.dash.account.general.model.Password;
 import io.saim.dash.account.general.model.SignupName;
 import io.saim.dash.account.general.repository.GeneralPasswordRepository;
@@ -17,6 +18,7 @@ public class LoginService {
 	private final SignupNameRepository signupNameRepository;
 	private final GeneralPasswordRepository passwordRepository;
 	private final BCryptPasswordEncoder passwordEncoder;
+	private final SessionManager sessionManager;
 
 	public LoginResponseDTO login(String generalPhone, String rawPassword) {
 		//사용자 정보 조회 (전화번호 기반)
@@ -41,6 +43,11 @@ public class LoginService {
 			throw new IllegalArgumentException("비밀번호가 올바르지 않습니다.");
 		}
 
+		//세션 생성 및 저장
+		String sessionId = generateSessionId();
+		sessionManager.createSession(sessionId, user.getGeneralId().toString()); //세션 저장
+		System.out.println("✅ 로그인 성공: 세션 생성됨 → " + sessionId);
+
 		return new LoginResponseDTO(
 			"success",
 			"로그인 성공",
@@ -51,7 +58,7 @@ public class LoginService {
 					user.getGeneralPhone(),
 					user.getGeneralType()
 				),
-				generateSessionId() //세션 ID 생성
+				sessionId //세션 ID 생성
 			)
 		);
 	}

--- a/src/main/java/io/saim/dash/account/auth/service/LoginService.java
+++ b/src/main/java/io/saim/dash/account/auth/service/LoginService.java
@@ -9,6 +9,8 @@ import io.saim.dash.account.general.repository.SignupNameRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Service;
+
+import java.util.List;
 import java.util.UUID;
 
 @Service
@@ -21,32 +23,26 @@ public class LoginService {
 	private final SessionManager sessionManager;
 
 	public LoginResponseDTO login(String generalPhone, String rawPassword) {
-		//사용자 정보 조회 (전화번호 기반)
+		//사용자 정보 조회
 		SignupName user = signupNameRepository.findByGeneralPhone(generalPhone)
 			.orElseThrow(() -> new IllegalArgumentException("등록되지 않은 전화번호입니다."));
 
-		//가장 최근 비밀번호 가져오기 (최신 createdAt 기준 정렬)
-		Password userPassword = passwordRepository.findByUser(user)
-			.stream()
-			.max((p1, p2) -> p1.getCreatedAt().compareTo(p2.getCreatedAt())) //최신 비밀번호 가져오기
-			.orElseThrow(() -> new IllegalArgumentException("비밀번호가 설정되지 않았습니다."));
+		//가장 최근 비밀번호 가져오기
+		List<Password> userPasswords = passwordRepository.findByUser(user);
+		Password userPassword = Password.getLatestPassword(userPasswords);
+		if (userPassword == null) {
+			throw new IllegalArgumentException("비밀번호가 설정되지 않았습니다.");
+		}
 
-		//비밀번호 비교 (비교 전 `trim()` 적용)
-		String inputPassword = rawPassword.trim();
-		String storedPassword = userPassword.getHashedPassword();
-
-		System.out.println("입력된 비밀번호: " + inputPassword);
-		System.out.println("DB에 저장된 해시 비밀번호: " + storedPassword);
-		System.out.println("비밀번호 일치 여부: " + passwordEncoder.matches(inputPassword, storedPassword));
-
-		if (!passwordEncoder.matches(inputPassword, storedPassword)) {
+		//비밀번호 검증
+		if (!user.isPasswordValid(rawPassword, userPassword, passwordEncoder)) {
 			throw new IllegalArgumentException("비밀번호가 올바르지 않습니다.");
 		}
 
 		//세션 생성 및 저장
 		String sessionId = generateSessionId();
 		sessionManager.createSession(sessionId, user.getGeneralId().toString()); //세션 저장
-		System.out.println("✅ 로그인 성공: 세션 생성됨 → " + sessionId);
+		System.out.println("로그인 성공: 세션 생성됨 → " + sessionId);
 
 		return new LoginResponseDTO(
 			"success",

--- a/src/main/java/io/saim/dash/account/auth/service/LogoutService.java
+++ b/src/main/java/io/saim/dash/account/auth/service/LogoutService.java
@@ -11,11 +11,8 @@ public class LogoutService {
 	private final SessionManager sessionManager;
 
 	public boolean invalidateSession(String sessionId) {
-		System.out.println("Checking session existence: " + sessionManager.isValidSession(sessionId));
-
 		if (sessionManager.isValidSession(sessionId)) {
 			sessionManager.invalidateSession(sessionId);
-			System.out.println("세션 삭제됨: " + sessionId);
 			return true;
 		}
 		return false;

--- a/src/main/java/io/saim/dash/account/auth/service/LogoutService.java
+++ b/src/main/java/io/saim/dash/account/auth/service/LogoutService.java
@@ -1,0 +1,23 @@
+package io.saim.dash.account.auth.service;
+
+import io.saim.dash.account.auth.session.SessionManager;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class LogoutService {
+
+	private final SessionManager sessionManager;
+
+	public boolean invalidateSession(String sessionId) {
+		System.out.println("Checking session existence: " + sessionManager.isValidSession(sessionId));
+
+		if (sessionManager.isValidSession(sessionId)) {
+			sessionManager.invalidateSession(sessionId);
+			System.out.println("세션 삭제됨: " + sessionId);
+			return true;
+		}
+		return false;
+	}
+}

--- a/src/main/java/io/saim/dash/account/auth/service/PasswordResetService.java
+++ b/src/main/java/io/saim/dash/account/auth/service/PasswordResetService.java
@@ -1,0 +1,55 @@
+package io.saim.dash.account.auth.service;
+
+import io.saim.dash.account.auth.dto.PasswordResetRequestDTO;
+import io.saim.dash.account.auth.dto.PasswordResetResponseDTO;
+import io.saim.dash.account.auth.model.PhoneVerification;
+import io.saim.dash.account.auth.repository.PhoneVerificationRepository;
+import io.saim.dash.account.general.model.Password;
+import io.saim.dash.account.general.model.SignupName;
+import io.saim.dash.account.general.repository.GeneralPasswordRepository;
+import io.saim.dash.account.general.repository.SignupNameRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class PasswordResetService {
+
+	private final SignupNameRepository signupNameRepository;
+	private final GeneralPasswordRepository passwordRepository;
+	private final PhoneVerificationRepository phoneVerificationRepository;
+	private final BCryptPasswordEncoder passwordEncoder;
+
+	@Transactional
+	public PasswordResetResponseDTO resetPassword(PasswordResetRequestDTO requestDTO) {
+		//전화번호 인증 여부 확인
+		PhoneVerification verification = phoneVerificationRepository.findByUserPhone(requestDTO.getUserPhone())
+			.orElseThrow(() -> new IllegalArgumentException("해당 전화번호의 인증 요청이 없습니다."));
+
+		if (!verification.isUserVerified()) {
+			throw new IllegalArgumentException("전화번호 인증이 완료되지 않았습니다.");
+		}
+
+		//사용자 조회
+		SignupName user = signupNameRepository.findByGeneralPhone(requestDTO.getUserPhone())
+			.orElseThrow(() -> new IllegalArgumentException("등록되지 않은 전화번호입니다."));
+
+		//비밀번호 확인 일치 여부 검증
+		if (!requestDTO.getNewPassword().equals(requestDTO.getNewPasswordConfirm())) {
+			throw new IllegalArgumentException("비밀번호가 일치하지 않습니다.");
+		}
+
+		//기존 비밀번호가 있는 경우 업데이트
+		Password password = passwordRepository.findByUser(user)
+			.orElse(new Password());
+
+		//새 비밀번호 암호화 후 저장
+		password.setUser(user);
+		password.setHashedPassword(passwordEncoder.encode(requestDTO.getNewPassword()));
+		passwordRepository.save(password);
+
+		return new PasswordResetResponseDTO("SUCCESS", "비밀번호가 성공적으로 재설정되었습니다.");
+	}
+}

--- a/src/main/java/io/saim/dash/account/auth/service/PasswordResetService.java
+++ b/src/main/java/io/saim/dash/account/auth/service/PasswordResetService.java
@@ -13,6 +13,8 @@ import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
+
 @Service
 @RequiredArgsConstructor
 public class PasswordResetService {
@@ -36,18 +38,20 @@ public class PasswordResetService {
 		SignupName user = signupNameRepository.findByGeneralPhone(requestDTO.getUserPhone())
 			.orElseThrow(() -> new IllegalArgumentException("등록되지 않은 전화번호입니다."));
 
+		//가장 최근 비밀번호 가져오기
+		List<Password> userPasswords = passwordRepository.findByUser(user);
+		Password password = userPasswords.stream()
+			.max((p1, p2) -> p1.getCreatedAt().compareTo(p2.getCreatedAt())) //최신 비밀번호 찾기
+			.orElse(new Password()); // 🔹 기본 비밀번호 객체 생성
+
 		//비밀번호 확인 일치 여부 검증
 		if (!requestDTO.getNewPassword().equals(requestDTO.getNewPasswordConfirm())) {
 			throw new IllegalArgumentException("비밀번호가 일치하지 않습니다.");
 		}
 
-		//기존 비밀번호가 있는 경우 업데이트
-		Password password = passwordRepository.findByUser(user)
-			.orElse(new Password());
-
-		//새 비밀번호 암호화 후 저장
+		//비밀번호 변경을 Password 엔티티 내에서 수행하도록 변경
 		password.setUser(user);
-		password.setHashedPassword(passwordEncoder.encode(requestDTO.getNewPassword()));
+		password.changePassword(requestDTO.getNewPassword(), passwordEncoder);
 		passwordRepository.save(password);
 
 		return new PasswordResetResponseDTO("SUCCESS", "비밀번호가 성공적으로 재설정되었습니다.");

--- a/src/main/java/io/saim/dash/account/auth/session/SessionManager.java
+++ b/src/main/java/io/saim/dash/account/auth/session/SessionManager.java
@@ -1,0 +1,27 @@
+package io.saim.dash.account.auth.session;
+
+import org.springframework.stereotype.Component;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+@Component
+public class SessionManager {
+
+	private final Map<String, String> sessionStore = new ConcurrentHashMap<>();
+
+	public void createSession(String sessionId, String userId) {
+		System.out.println("세션 생성: " + sessionId + " for user " + userId);
+		sessionStore.put(sessionId, userId);
+	}
+
+	public boolean isValidSession(String sessionId) {
+		System.out.println("세션 유효성 검사: " + sessionId + " 존재? " + sessionStore.containsKey(sessionId));
+		return sessionStore.containsKey(sessionId);
+	}
+
+	public void invalidateSession(String sessionId) {
+		System.out.println("세션 삭제: " + sessionId);
+		sessionStore.remove(sessionId);
+	}
+}

--- a/src/main/java/io/saim/dash/account/auth/session/SessionManager.java
+++ b/src/main/java/io/saim/dash/account/auth/session/SessionManager.java
@@ -24,4 +24,8 @@ public class SessionManager {
 		System.out.println("세션 삭제: " + sessionId);
 		sessionStore.remove(sessionId);
 	}
+
+	public String getUserIdFromSession(String sessionId) {
+		return sessionStore.get(sessionId);
+	}
 }

--- a/src/main/java/io/saim/dash/account/general/controller/GeneralAccountController.java
+++ b/src/main/java/io/saim/dash/account/general/controller/GeneralAccountController.java
@@ -3,6 +3,7 @@ package io.saim.dash.account.general.controller;
 import java.util.Map;
 
 import io.saim.dash.account.general.dto.GeneralAccountResponseDTO;
+import io.saim.dash.account.general.dto.GeneralEmailVerifyConfirmDTO;
 import io.saim.dash.account.general.dto.GeneralEmailVerifyRequestDTO;
 import io.saim.dash.account.general.dto.GeneralPhoneUpdateDTO;
 import io.saim.dash.account.general.service.GeneralAccountService;
@@ -72,6 +73,27 @@ public class GeneralAccountController {
 			return ResponseEntity.status(400).body(Map.of(
 				"status", "failure",
 				"message", "이메일 인증 요청을 실패했습니다."
+			));
+		}
+	}
+
+	//이메일 변경 인증 코드 확인
+	@PostMapping("/account/email-verify/confirm")
+	public ResponseEntity<?> confirmEmailVerification(
+		@RequestHeader("Authorization") String sessionId,
+		@RequestBody GeneralEmailVerifyConfirmDTO confirmDTO) {
+
+		boolean isConfirmed = generalAccountService.confirmEmailVerification(sessionId, confirmDTO);
+
+		if (isConfirmed) {
+			return ResponseEntity.ok(Map.of(
+				"status", "SUCCESS",
+				"message", "인증이 완료되었습니다."
+			));
+		} else {
+			return ResponseEntity.status(400).body(Map.of(
+				"status", "failure",
+				"message", "인증 코드가 올바르지 않거나 만료되었습니다."
 			));
 		}
 	}

--- a/src/main/java/io/saim/dash/account/general/controller/GeneralAccountController.java
+++ b/src/main/java/io/saim/dash/account/general/controller/GeneralAccountController.java
@@ -97,4 +97,22 @@ public class GeneralAccountController {
 			));
 		}
 	}
+
+	//회원 탈퇴
+	@DeleteMapping("/account/delete")
+	public ResponseEntity<?> deleteAccount(@RequestHeader("Authorization") String sessionId) {
+		boolean isDeleted = generalAccountService.deleteAccount(sessionId);
+
+		if (isDeleted) {
+			return ResponseEntity.ok(Map.of(
+				"status", "SUCCESS",
+				"message", "회원 탈퇴가 완료되었습니다."
+			));
+		} else {
+			return ResponseEntity.status(403).body(Map.of(
+				"status", "FAILED",
+				"message", "회원 탈퇴에 실패했습니다. 유효한 세션이 아닙니다."
+			));
+		}
+	}
 }

--- a/src/main/java/io/saim/dash/account/general/controller/GeneralAccountController.java
+++ b/src/main/java/io/saim/dash/account/general/controller/GeneralAccountController.java
@@ -2,11 +2,11 @@ package io.saim.dash.account.general.controller;
 
 import java.util.Map;
 
-import io.saim.dash.account.general.dto.GeneralAccountResponseDTO;
-import io.saim.dash.account.general.dto.GeneralEmailVerifyConfirmDTO;
-import io.saim.dash.account.general.dto.GeneralEmailVerifyRequestDTO;
-import io.saim.dash.account.general.dto.GeneralPhoneUpdateDTO;
+import io.saim.dash.account.general.dto.*;
 import io.saim.dash.account.general.service.GeneralAccountService;
+import io.saim.dash.global.dto.CommonResponseDTO;
+import io.saim.dash.global.dto.CommonResponseDTO.VersionResponseDTO;
+import io.saim.dash.global.dto.APIStatus;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -18,100 +18,119 @@ public class GeneralAccountController {
 
 	private final GeneralAccountService generalAccountService;
 
-	//계정 상세 조회 기능
+	// 계정 상세 조회 기능
 	@GetMapping("/account")
-	public ResponseEntity<GeneralAccountResponseDTO> getGeneralAccountDetails(@RequestHeader("Authorization") String token) {
+	public ResponseEntity<CommonResponseDTO<GeneralAccountResponseDTO.Data>> getGeneralAccountDetails(
+		@RequestHeader("Authorization") String token) {
+
 		GeneralAccountResponseDTO response = generalAccountService.getGeneralAccountDetails(token);
 		return ResponseEntity.ok(response);
 	}
 
-	//신규 전화번호 변경 기능
+	// 신규 전화번호 변경 기능
 	@PatchMapping("/account/phone")
-	public ResponseEntity<?> updatePhoneNumber(
+	public ResponseEntity<CommonResponseDTO<?>> updatePhoneNumber(
 		@RequestHeader("Authorization") String sessionId,
 		@RequestBody GeneralPhoneUpdateDTO updateDTO) {
+
 		boolean isUpdated = generalAccountService.updatePhoneNumber(sessionId, updateDTO);
 
 		if (isUpdated) {
-			return ResponseEntity.ok(Map.of(
-				"status", "SUCCESS",
-				"message", "전화번호가 성공적으로 변경되었습니다.",
-				"data", Map.of("general_new_phone", updateDTO.getGeneralNewPhone())
+			return ResponseEntity.ok(new CommonResponseDTO<>(
+				new VersionResponseDTO("1.0", "1.0"),
+				APIStatus.SUCCESS,
+				"전화번호가 성공적으로 변경되었습니다.",
+				Map.of("general_new_phone", updateDTO.getGeneralNewPhone())
 			));
 		} else {
-			return ResponseEntity.status(400).body(Map.of(
-				"status", "failure",
-				"message", "전화번호 변경에 실패했습니다. 인증 코드를 확인하세요."
+			return ResponseEntity.badRequest().body(new CommonResponseDTO<>(
+				new VersionResponseDTO("1.0", "1.0"),
+				APIStatus.FAILURE,
+				"전화번호 변경에 실패했습니다. 인증 코드를 확인하세요.",
+				null
 			));
 		}
 	}
 
-	//이메일 변경 인증 요청
+	// 이메일 변경 인증 요청
 	@PostMapping("/account/email-verify/request")
-	public ResponseEntity<?> requestEmailVerification(
+	public ResponseEntity<CommonResponseDTO<?>> requestEmailVerification(
 		@RequestHeader("Authorization") String sessionId,
 		@RequestBody Map<String, String> requestBody) {
 
 		String newEmail = requestBody.get("new_email");
 
 		if (newEmail == null || newEmail.isBlank()) {
-			return ResponseEntity.badRequest().body(Map.of(
-				"status", "failure",
-				"message", "새로운 이메일을 입력해야 합니다."
+			return ResponseEntity.badRequest().body(new CommonResponseDTO<>(
+				new VersionResponseDTO("1.0", "1.0"),
+				APIStatus.FAILURE,
+				"새로운 이메일을 입력해야 합니다.",
+				null
 			));
 		}
 
 		boolean isSent = generalAccountService.requestEmailVerification(sessionId, newEmail);
 
 		if (isSent) {
-			return ResponseEntity.ok(Map.of(
-				"status", "SUCCESS",
-				"message", "인증 코드가 이메일로 전송되었습니다.",
-				"data", Map.of("expires_in", 180)
+			return ResponseEntity.ok(new CommonResponseDTO<>(
+				new VersionResponseDTO("1.0", "1.0"),
+				APIStatus.SUCCESS,
+				"인증 코드가 이메일로 전송되었습니다.",
+				Map.of("expires_in", 180) // 인증 코드 만료 시간
 			));
 		} else {
-			return ResponseEntity.status(400).body(Map.of(
-				"status", "failure",
-				"message", "이메일 인증 요청을 실패했습니다."
+			return ResponseEntity.badRequest().body(new CommonResponseDTO<>(
+				new VersionResponseDTO("1.0", "1.0"),
+				APIStatus.FAILURE,
+				"이메일 인증 요청을 실패했습니다.",
+				null
 			));
 		}
 	}
 
-	//이메일 변경 인증 코드 확인
+	// 이메일 변경 인증 코드 확인
 	@PostMapping("/account/email-verify/confirm")
-	public ResponseEntity<?> confirmEmailVerification(
+	public ResponseEntity<CommonResponseDTO<?>> confirmEmailVerification(
 		@RequestHeader("Authorization") String sessionId,
 		@RequestBody GeneralEmailVerifyConfirmDTO confirmDTO) {
 
 		boolean isConfirmed = generalAccountService.confirmEmailVerification(sessionId, confirmDTO);
 
 		if (isConfirmed) {
-			return ResponseEntity.ok(Map.of(
-				"status", "SUCCESS",
-				"message", "인증이 완료되었습니다."
+			return ResponseEntity.ok(new CommonResponseDTO<>(
+				new VersionResponseDTO("1.0", "1.0"),
+				APIStatus.SUCCESS,
+				"인증이 완료되었습니다.",
+				null
 			));
 		} else {
-			return ResponseEntity.status(400).body(Map.of(
-				"status", "failure",
-				"message", "인증 코드가 올바르지 않거나 만료되었습니다."
+			return ResponseEntity.badRequest().body(new CommonResponseDTO<>(
+				new VersionResponseDTO("1.0", "1.0"),
+				APIStatus.FAILURE,
+				"인증 코드가 올바르지 않거나 만료되었습니다.",
+				null
 			));
 		}
 	}
 
-	//회원 탈퇴
+	// 회원 탈퇴
 	@DeleteMapping("/account/delete")
-	public ResponseEntity<?> deleteAccount(@RequestHeader("Authorization") String sessionId) {
+	public ResponseEntity<CommonResponseDTO<?>> deleteAccount(@RequestHeader("Authorization") String sessionId) {
 		boolean isDeleted = generalAccountService.deleteAccount(sessionId);
 
 		if (isDeleted) {
-			return ResponseEntity.ok(Map.of(
-				"status", "SUCCESS",
-				"message", "회원 탈퇴가 완료되었습니다."
+			return ResponseEntity.ok(new CommonResponseDTO<>(
+				new VersionResponseDTO("1.0", "1.0"),
+				APIStatus.SUCCESS,
+				"회원 탈퇴가 완료되었습니다.",
+				null
 			));
 		} else {
-			return ResponseEntity.status(403).body(Map.of(
-				"status", "FAILED",
-				"message", "회원 탈퇴에 실패했습니다. 유효한 세션이 아닙니다."
+			return ResponseEntity.status(403).body(new CommonResponseDTO<>(
+				new VersionResponseDTO("1.0", "1.0"),
+				APIStatus.FAILURE,
+				"회원 탈퇴에 실패했습니다. 유효한 세션이 아닙니다.",
+				null
 			));
 		}
 	}

--- a/src/main/java/io/saim/dash/account/general/controller/GeneralAccountController.java
+++ b/src/main/java/io/saim/dash/account/general/controller/GeneralAccountController.java
@@ -1,0 +1,21 @@
+package io.saim.dash.account.general.controller;
+
+import io.saim.dash.account.general.dto.GeneralAccountResponseDTO;
+import io.saim.dash.account.general.service.GeneralAccountService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/general")
+@RequiredArgsConstructor
+public class GeneralAccountController {
+
+	private final GeneralAccountService generalAccountService;
+
+	@GetMapping("/account")
+	public ResponseEntity<GeneralAccountResponseDTO> getGeneralAccountDetails(@RequestHeader("Authorization") String token) {
+		GeneralAccountResponseDTO response = generalAccountService.getGeneralAccountDetails(token);
+		return ResponseEntity.ok(response);
+	}
+}

--- a/src/main/java/io/saim/dash/account/general/controller/GeneralAccountController.java
+++ b/src/main/java/io/saim/dash/account/general/controller/GeneralAccountController.java
@@ -3,6 +3,7 @@ package io.saim.dash.account.general.controller;
 import java.util.Map;
 
 import io.saim.dash.account.general.dto.GeneralAccountResponseDTO;
+import io.saim.dash.account.general.dto.GeneralEmailVerifyRequestDTO;
 import io.saim.dash.account.general.dto.GeneralPhoneUpdateDTO;
 import io.saim.dash.account.general.service.GeneralAccountService;
 import lombok.RequiredArgsConstructor;
@@ -40,6 +41,37 @@ public class GeneralAccountController {
 			return ResponseEntity.status(400).body(Map.of(
 				"status", "failure",
 				"message", "전화번호 변경에 실패했습니다. 인증 코드를 확인하세요."
+			));
+		}
+	}
+
+	//이메일 변경 인증 요청
+	@PostMapping("/account/email-verify/request")
+	public ResponseEntity<?> requestEmailVerification(
+		@RequestHeader("Authorization") String sessionId,
+		@RequestBody Map<String, String> requestBody) {
+
+		String newEmail = requestBody.get("new_email");
+
+		if (newEmail == null || newEmail.isBlank()) {
+			return ResponseEntity.badRequest().body(Map.of(
+				"status", "failure",
+				"message", "새로운 이메일을 입력해야 합니다."
+			));
+		}
+
+		boolean isSent = generalAccountService.requestEmailVerification(sessionId, newEmail);
+
+		if (isSent) {
+			return ResponseEntity.ok(Map.of(
+				"status", "SUCCESS",
+				"message", "인증 코드가 이메일로 전송되었습니다.",
+				"data", Map.of("expires_in", 180)
+			));
+		} else {
+			return ResponseEntity.status(400).body(Map.of(
+				"status", "failure",
+				"message", "이메일 인증 요청을 실패했습니다."
 			));
 		}
 	}

--- a/src/main/java/io/saim/dash/account/general/controller/GeneralAccountController.java
+++ b/src/main/java/io/saim/dash/account/general/controller/GeneralAccountController.java
@@ -1,6 +1,9 @@
 package io.saim.dash.account.general.controller;
 
+import java.util.Map;
+
 import io.saim.dash.account.general.dto.GeneralAccountResponseDTO;
+import io.saim.dash.account.general.dto.GeneralPhoneUpdateDTO;
 import io.saim.dash.account.general.service.GeneralAccountService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -13,9 +16,31 @@ public class GeneralAccountController {
 
 	private final GeneralAccountService generalAccountService;
 
+	//계정 상세 조회 기능
 	@GetMapping("/account")
 	public ResponseEntity<GeneralAccountResponseDTO> getGeneralAccountDetails(@RequestHeader("Authorization") String token) {
 		GeneralAccountResponseDTO response = generalAccountService.getGeneralAccountDetails(token);
 		return ResponseEntity.ok(response);
+	}
+
+	//신규 전화번호 변경 기능
+	@PatchMapping("/account/phone")
+	public ResponseEntity<?> updatePhoneNumber(
+		@RequestHeader("Authorization") String sessionId,
+		@RequestBody GeneralPhoneUpdateDTO updateDTO) {
+		boolean isUpdated = generalAccountService.updatePhoneNumber(sessionId, updateDTO);
+
+		if (isUpdated) {
+			return ResponseEntity.ok(Map.of(
+				"status", "SUCCESS",
+				"message", "전화번호가 성공적으로 변경되었습니다.",
+				"data", Map.of("general_new_phone", updateDTO.getGeneralNewPhone())
+			));
+		} else {
+			return ResponseEntity.status(400).body(Map.of(
+				"status", "failure",
+				"message", "전화번호 변경에 실패했습니다. 인증 코드를 확인하세요."
+			));
+		}
 	}
 }

--- a/src/main/java/io/saim/dash/account/general/controller/MyPageController.java
+++ b/src/main/java/io/saim/dash/account/general/controller/MyPageController.java
@@ -1,0 +1,21 @@
+package io.saim.dash.account.general.controller;
+
+import io.saim.dash.account.general.dto.MyPageResponseDTO;
+import io.saim.dash.account.general.service.MyPageService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/general")
+@RequiredArgsConstructor
+public class MyPageController {
+
+	private final MyPageService myPageService;
+
+	@GetMapping("/mypage")
+	public ResponseEntity<MyPageResponseDTO> getMyPage(@RequestHeader("Authorization") String sessionId) {
+		MyPageResponseDTO response = myPageService.getMyPageInfo(sessionId);
+		return ResponseEntity.ok(response);
+	}
+}

--- a/src/main/java/io/saim/dash/account/general/dto/GeneralAccountResponseDTO.java
+++ b/src/main/java/io/saim/dash/account/general/dto/GeneralAccountResponseDTO.java
@@ -1,23 +1,29 @@
 package io.saim.dash.account.general.dto;
 
-import lombok.AllArgsConstructor;
+import io.saim.dash.global.dto.APIStatus;
+import io.saim.dash.global.dto.CommonResponseDTO;
 import lombok.Getter;
 import lombok.Setter;
 
 @Getter
 @Setter
-@AllArgsConstructor
-public class GeneralAccountResponseDTO {
-	private String status;
-	private String message;
-	private Data data;
+public class GeneralAccountResponseDTO extends CommonResponseDTO<GeneralAccountResponseDTO.Data> {
+
+	public GeneralAccountResponseDTO(String apiVersion, String clientVersion, APIStatus status, String message, Data data) {
+		super(new VersionResponseDTO(apiVersion, clientVersion), status, message, data);
+	}
 
 	@Getter
 	@Setter
-	@AllArgsConstructor
 	public static class Data {
 		private String generalName;
 		private String generalEmail;
 		private String generalPhone;
+
+		public Data(String generalName, String generalEmail, String generalPhone) {
+			this.generalName = generalName;
+			this.generalEmail = generalEmail;
+			this.generalPhone = generalPhone;
+		}
 	}
 }

--- a/src/main/java/io/saim/dash/account/general/dto/GeneralAccountResponseDTO.java
+++ b/src/main/java/io/saim/dash/account/general/dto/GeneralAccountResponseDTO.java
@@ -1,0 +1,23 @@
+package io.saim.dash.account.general.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+public class GeneralAccountResponseDTO {
+	private String status;
+	private String message;
+	private Data data;
+
+	@Getter
+	@Setter
+	@AllArgsConstructor
+	public static class Data {
+		private String generalName;
+		private String generalEmail;
+		private String generalPhone;
+	}
+}

--- a/src/main/java/io/saim/dash/account/general/dto/GeneralEmailVerifyConfirmDTO.java
+++ b/src/main/java/io/saim/dash/account/general/dto/GeneralEmailVerifyConfirmDTO.java
@@ -1,0 +1,16 @@
+package io.saim.dash.account.general.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+import lombok.Setter;
+
+@Setter
+@Getter
+public class GeneralEmailVerifyConfirmDTO {
+
+	@JsonProperty("new_email")
+	private String newEmail;
+
+	@JsonProperty("email_verify_code")
+	private String emailVerifyCode;
+}

--- a/src/main/java/io/saim/dash/account/general/dto/GeneralEmailVerifyRequestDTO.java
+++ b/src/main/java/io/saim/dash/account/general/dto/GeneralEmailVerifyRequestDTO.java
@@ -1,0 +1,12 @@
+package io.saim.dash.account.general.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+import lombok.Setter;
+
+@Setter
+@Getter
+public class GeneralEmailVerifyRequestDTO {
+	@JsonProperty("new_email")
+	private String newEmail;
+}

--- a/src/main/java/io/saim/dash/account/general/dto/GeneralPasswordRequestDTO.java
+++ b/src/main/java/io/saim/dash/account/general/dto/GeneralPasswordRequestDTO.java
@@ -2,6 +2,7 @@ package io.saim.dash.account.general.dto;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 import lombok.Getter;
@@ -11,7 +12,7 @@ import lombok.Setter;
 @Setter
 public class GeneralPasswordRequestDTO {
 
-	@NotBlank(message = "사용자 ID는 필수입니다.")
+	@NotNull(message = "사용자 ID는 필수입니다.")
 	@JsonProperty("general_id")
 	private Long generalId;
 

--- a/src/main/java/io/saim/dash/account/general/dto/GeneralPhoneUpdateDTO.java
+++ b/src/main/java/io/saim/dash/account/general/dto/GeneralPhoneUpdateDTO.java
@@ -1,0 +1,15 @@
+package io.saim.dash.account.general.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+import lombok.Setter;
+
+@Setter
+@Getter
+public class GeneralPhoneUpdateDTO {
+	@JsonProperty("general_new_phone")
+	private String generalNewPhone;
+
+	@JsonProperty("general_verify_code")
+	private String generalVerifyCode;
+}

--- a/src/main/java/io/saim/dash/account/general/dto/MyPageResponseDTO.java
+++ b/src/main/java/io/saim/dash/account/general/dto/MyPageResponseDTO.java
@@ -1,0 +1,54 @@
+package io.saim.dash.account.general.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+public class MyPageResponseDTO {
+	private String status;
+	private String message;
+	private Data data;
+
+	@Getter
+	@Setter
+	@AllArgsConstructor
+	public static class Data {
+		private String generalName;
+		private CouponStatus couponStatus;
+		private Menus menus;
+	}
+
+	@Getter
+	@Setter
+	@AllArgsConstructor
+	public static class CouponStatus {
+		private int usableCoupons;
+		private int usedCoupons;
+	}
+
+	@Getter
+	@Setter
+	public static class Menus {
+		private MenuItem[] myInfo = {
+			new MenuItem("계정 정보", "/general/account"),
+			new MenuItem("비밀번호 변경하기", "/auth/password-reset/request")
+		};
+
+		private MenuItem[] customerCenter = {
+			new MenuItem("공지사항", "/support/notice"),
+			new MenuItem("FAQ", "/support/faq"),
+			new MenuItem("문의하기", "/support/contact")
+		};
+
+		@Getter
+		@Setter
+		@AllArgsConstructor
+		public static class MenuItem {
+			private String title;
+			private String url;
+		}
+	}
+}

--- a/src/main/java/io/saim/dash/account/general/model/EmailVerification.java
+++ b/src/main/java/io/saim/dash/account/general/model/EmailVerification.java
@@ -1,0 +1,27 @@
+package io.saim.dash.account.general.model;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@Setter
+@Table(name = "email_verification")
+public class EmailVerification {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@Column(nullable = false, unique = true)
+	private String email;
+
+	@Column(nullable = false)
+	private String verificationCode;
+
+	@Column(nullable = false)
+	private LocalDateTime expiresAt;
+}

--- a/src/main/java/io/saim/dash/account/general/model/Password.java
+++ b/src/main/java/io/saim/dash/account/general/model/Password.java
@@ -4,8 +4,10 @@ import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.Setter;
 import org.hibernate.annotations.CreationTimestamp;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 @Setter
 @Getter
@@ -26,4 +28,16 @@ public class Password {
 
 	@CreationTimestamp
 	private LocalDateTime createdAt;  //등록 시간 자동 생성
+
+	//가장 최근 비밀번호 가져오는 정적 메서드 추가
+	public static Password getLatestPassword(List<Password> passwords) {
+		return passwords.stream()
+			.max((p1, p2) -> p1.getCreatedAt().compareTo(p2.getCreatedAt()))
+			.orElse(null);
+	}
+
+	//비밀번호 변경 메서드 추가
+	public void changePassword(String newPassword, BCryptPasswordEncoder encoder) {
+		this.hashedPassword = encoder.encode(newPassword);
+	}
 }

--- a/src/main/java/io/saim/dash/account/general/model/SignupName.java
+++ b/src/main/java/io/saim/dash/account/general/model/SignupName.java
@@ -24,6 +24,10 @@ public class SignupName {
 
 	@Column(unique = true, nullable = false)
 	private String generalPhone;
+
+	@Column(unique = true)
+	private String sessionId;
+
 	private LocalDateTime joinedAt;
 	private Long vendorGroupId;
 	private Long departmentId;

--- a/src/main/java/io/saim/dash/account/general/model/SignupName.java
+++ b/src/main/java/io/saim/dash/account/general/model/SignupName.java
@@ -3,6 +3,7 @@ package io.saim.dash.account.general.model;
 import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.Setter;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -34,4 +35,9 @@ public class SignupName {
 
 	@OneToMany(mappedBy = "user", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
 	private List<Password> passwords;
+
+	//비밀번호 검증 메서드 추가
+	public boolean isPasswordValid(String rawPassword, Password password, BCryptPasswordEncoder encoder) {
+		return encoder.matches(rawPassword.trim(), password.getHashedPassword());
+	}
 }

--- a/src/main/java/io/saim/dash/account/general/repository/EmailVerifyRepository.java
+++ b/src/main/java/io/saim/dash/account/general/repository/EmailVerifyRepository.java
@@ -1,0 +1,10 @@
+package io.saim.dash.account.general.repository;
+
+import io.saim.dash.account.general.model.EmailVerification;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface EmailVerifyRepository extends JpaRepository<EmailVerification, Long> {
+	Optional<EmailVerification> findByEmail(String email);
+}

--- a/src/main/java/io/saim/dash/account/general/repository/GeneralPasswordRepository.java
+++ b/src/main/java/io/saim/dash/account/general/repository/GeneralPasswordRepository.java
@@ -3,8 +3,8 @@ package io.saim.dash.account.general.repository;
 import io.saim.dash.account.general.model.Password;
 import io.saim.dash.account.general.model.SignupName;
 import org.springframework.data.jpa.repository.JpaRepository;
-import java.util.Optional;
+import java.util.List;
 
 public interface GeneralPasswordRepository extends JpaRepository<Password, Long> {
-	Optional<Password> findByUser(SignupName user);
+	List<Password> findByUser(SignupName user);
 }

--- a/src/main/java/io/saim/dash/account/general/service/EmailVerifyService.java
+++ b/src/main/java/io/saim/dash/account/general/service/EmailVerifyService.java
@@ -1,0 +1,73 @@
+package io.saim.dash.account.general.service;
+
+import io.saim.dash.account.auth.session.SessionManager;
+import io.saim.dash.account.general.model.EmailVerification;
+import io.saim.dash.account.general.model.SignupName;
+import io.saim.dash.account.general.repository.EmailVerifyRepository;
+import io.saim.dash.account.general.repository.SignupNameRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.Random;
+
+@Service
+@RequiredArgsConstructor
+public class EmailVerifyService {
+
+	private final EmailVerifyRepository emailVerificationRepository;
+	private final SessionManager sessionManager;
+	private final SignupNameRepository signupNameRepository;
+
+	//인증 코드 생성 및 이메일 전송
+	public boolean sendVerificationCode(String email) {
+		String verificationCode = generateCode();
+		LocalDateTime expirationTime = LocalDateTime.now().plusMinutes(3);
+
+		//기존 이메일 인증 정보가 있으면 삭제
+		emailVerificationRepository.findByEmail(email).ifPresent(emailVerificationRepository::delete);
+
+		//새로운 인증 정보 저장
+		EmailVerification emailVerification = new EmailVerification();
+		emailVerification.setEmail(email);
+		emailVerification.setVerificationCode(verificationCode);
+		emailVerification.setExpiresAt(expirationTime);
+
+		emailVerificationRepository.save(emailVerification);
+
+		//실제 이메일 발송 로직 (추후 구현 가능)
+		System.out.println("인증 코드: " + verificationCode + " (이메일: " + email + ")");
+
+		return true;
+	}
+
+	//이메일 변경을 위한 인증 요청
+	@Transactional
+	public boolean requestEmailVerification(String sessionId, String newEmail) {
+		//세션 ID를 통해 사용자 ID 조회
+		String userId = sessionManager.getUserIdFromSession(sessionId);
+		if (userId == null) {
+			throw new IllegalArgumentException("유효하지 않은 세션입니다.");
+		}
+
+		//사용자 정보 조회
+		SignupName user = signupNameRepository.findById(Long.parseLong(userId))
+			.orElseThrow(() -> new IllegalArgumentException("사용자 정보를 찾을 수 없습니다."));
+
+		//디버깅용 기존 이메일 출력
+		System.out.println("기존 이메일: " + user.getGeneralEmail());
+
+		//새로운 이메일로 인증 요청
+		return sendVerificationCode(newEmail);
+	}
+
+	/**
+	 * ✅ 인증 코드 생성 메서드 (랜덤 6자리 숫자)
+	 */
+	private String generateCode() {
+		Random random = new Random();
+		int code = 100000 + random.nextInt(900000); // 100000 ~ 999999 범위의 숫자
+		return String.valueOf(code);
+	}
+}

--- a/src/main/java/io/saim/dash/account/general/service/GeneralAccountService.java
+++ b/src/main/java/io/saim/dash/account/general/service/GeneralAccountService.java
@@ -1,9 +1,14 @@
 package io.saim.dash.account.general.service;
 
+import java.time.LocalDateTime;
+
 import io.saim.dash.account.auth.service.PhoneVerificationService;
 import io.saim.dash.account.general.dto.GeneralAccountResponseDTO;
+import io.saim.dash.account.general.dto.GeneralEmailVerifyConfirmDTO;
 import io.saim.dash.account.general.dto.GeneralPhoneUpdateDTO;
+import io.saim.dash.account.general.model.EmailVerification;
 import io.saim.dash.account.general.model.SignupName;
+import io.saim.dash.account.general.repository.EmailVerifyRepository;
 import io.saim.dash.account.general.repository.SignupNameRepository;
 import io.saim.dash.account.auth.session.SessionManager;
 import lombok.RequiredArgsConstructor;
@@ -18,6 +23,7 @@ public class GeneralAccountService {
 	private final SessionManager sessionManager;
 	private final PhoneVerificationService phoneVerificationService;
 	private final EmailVerifyService emailVerificationService;
+	private final EmailVerifyRepository emailVerifyRepository;
 
 	public GeneralAccountResponseDTO getGeneralAccountDetails(String sessionId) {
 		//세션 ID를 통해 사용자 ID 조회
@@ -77,5 +83,41 @@ public class GeneralAccountService {
 
 		//이메일 인증 요청 수행
 		return emailVerificationService.sendVerificationCode(newEmail);
+	}
+
+	@Transactional
+	public boolean confirmEmailVerification(String sessionId, GeneralEmailVerifyConfirmDTO confirmDTO) {
+		//세션 ID를 통해 사용자 ID 조회
+		String userId = sessionManager.getUserIdFromSession(sessionId);
+		if (userId == null) {
+			throw new IllegalArgumentException("유효하지 않은 세션입니다.");
+		}
+
+		//사용자 정보 조회
+		SignupName user = signupNameRepository.findById(Long.parseLong(userId))
+			.orElseThrow(() -> new IllegalArgumentException("사용자 정보를 찾을 수 없습니다."));
+
+		//인증 요청된 이메일 데이터 조회
+		EmailVerification verification = emailVerifyRepository.findByEmail(confirmDTO.getNewEmail())
+			.orElseThrow(() -> new IllegalArgumentException("이메일 인증 요청을 찾을 수 없습니다."));
+
+		//인증 코드 검증
+		if (!verification.getVerificationCode().equals(confirmDTO.getEmailVerifyCode())) {
+			return false;
+		}
+
+		//인증 코드 만료 여부 확인
+		if (verification.getExpiresAt().isBefore(LocalDateTime.now())) {
+			return false;
+		}
+
+		//이메일 업데이트
+		user.setGeneralEmail(confirmDTO.getNewEmail());
+		signupNameRepository.save(user);
+
+		// 인증 정보 삭제 (사용 완료된 인증 코드)
+		emailVerifyRepository.delete(verification);
+
+		return true;
 	}
 }

--- a/src/main/java/io/saim/dash/account/general/service/GeneralAccountService.java
+++ b/src/main/java/io/saim/dash/account/general/service/GeneralAccountService.java
@@ -17,6 +17,7 @@ public class GeneralAccountService {
 	private final SignupNameRepository signupNameRepository;
 	private final SessionManager sessionManager;
 	private final PhoneVerificationService phoneVerificationService;
+	private final EmailVerifyService emailVerificationService;
 
 	public GeneralAccountResponseDTO getGeneralAccountDetails(String sessionId) {
 		//세션 ID를 통해 사용자 ID 조회
@@ -60,7 +61,21 @@ public class GeneralAccountService {
 		//전화번호 업데이트
 		user.setGeneralPhone(newPhone);
 		signupNameRepository.save(user);
-
 		return true;
+	}
+
+	public boolean requestEmailVerification(String sessionId, String newEmail) {
+		//세션 ID를 통해 사용자 찾기
+		String userId = sessionManager.getUserIdFromSession(sessionId);
+		if (userId == null) {
+			throw new IllegalArgumentException("유효하지 않은 세션입니다.");
+		}
+
+		//기존 사용자 정보 가져오기
+		SignupName user = signupNameRepository.findById(Long.parseLong(userId))
+			.orElseThrow(() -> new IllegalArgumentException("사용자 정보를 찾을 수 없습니다."));
+
+		//이메일 인증 요청 수행
+		return emailVerificationService.sendVerificationCode(newEmail);
 	}
 }

--- a/src/main/java/io/saim/dash/account/general/service/GeneralAccountService.java
+++ b/src/main/java/io/saim/dash/account/general/service/GeneralAccountService.java
@@ -11,6 +11,7 @@ import io.saim.dash.account.general.model.SignupName;
 import io.saim.dash.account.general.repository.EmailVerifyRepository;
 import io.saim.dash.account.general.repository.SignupNameRepository;
 import io.saim.dash.account.auth.session.SessionManager;
+import io.saim.dash.global.dto.APIStatus;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -40,7 +41,7 @@ public class GeneralAccountService {
 		String email = (user.getGeneralEmail() == null || user.getGeneralEmail().isBlank())
 			? "등록된 이메일이 없습니다." : user.getGeneralEmail();
 
-		return new GeneralAccountResponseDTO("SUCCESS", "계정 상세 정보를 성공적으로 가져왔습니다.",
+		return new GeneralAccountResponseDTO("1.0", "1.0",  APIStatus.SUCCESS, "계정 상세 정보를 성공적으로 가져왔습니다.",
 			new GeneralAccountResponseDTO.Data(user.getGeneralName(), email, user.getGeneralPhone()));
 	}
 
@@ -127,7 +128,7 @@ public class GeneralAccountService {
 		//세션 ID로 사용자 조회
 		String userId = sessionManager.getUserIdFromSession(sessionId);
 		if (userId == null) {
-			return false; // 유효하지 않은 세션
+			return false; //유효하지 않은 세션
 		}
 
 		//사용자 정보 조회

--- a/src/main/java/io/saim/dash/account/general/service/GeneralAccountService.java
+++ b/src/main/java/io/saim/dash/account/general/service/GeneralAccountService.java
@@ -101,7 +101,7 @@ public class GeneralAccountService {
 		EmailVerification verification = emailVerifyRepository.findByEmail(confirmDTO.getNewEmail())
 			.orElseThrow(() -> new IllegalArgumentException("이메일 인증 요청을 찾을 수 없습니다."));
 
-		//인증 코드 검증
+		//인증 코드 확인
 		if (!verification.getVerificationCode().equals(confirmDTO.getEmailVerifyCode())) {
 			return false;
 		}
@@ -115,8 +115,34 @@ public class GeneralAccountService {
 		user.setGeneralEmail(confirmDTO.getNewEmail());
 		signupNameRepository.save(user);
 
-		// 인증 정보 삭제 (사용 완료된 인증 코드)
+		//인증 정보 삭제 (사용 완료된 인증 코드)
 		emailVerifyRepository.delete(verification);
+
+		return true;
+	}
+
+	//회원 탈퇴 로직
+	@Transactional
+	public boolean deleteAccount(String sessionId) {
+		//세션 ID로 사용자 조회
+		String userId = sessionManager.getUserIdFromSession(sessionId);
+		if (userId == null) {
+			return false; // 유효하지 않은 세션
+		}
+
+		//사용자 정보 조회
+		SignupName user = signupNameRepository.findById(Long.parseLong(userId))
+			.orElse(null);
+
+		if (user == null) {
+			return false; //이미 탈퇴했거나 존재하지 않는 사용자
+		}
+
+		//사용자 계정 삭제
+		signupNameRepository.delete(user);
+
+		//세션 무효화
+		sessionManager.invalidateSession(sessionId);
 
 		return true;
 	}

--- a/src/main/java/io/saim/dash/account/general/service/GeneralAccountService.java
+++ b/src/main/java/io/saim/dash/account/general/service/GeneralAccountService.java
@@ -1,11 +1,14 @@
 package io.saim.dash.account.general.service;
 
+import io.saim.dash.account.auth.service.PhoneVerificationService;
 import io.saim.dash.account.general.dto.GeneralAccountResponseDTO;
+import io.saim.dash.account.general.dto.GeneralPhoneUpdateDTO;
 import io.saim.dash.account.general.model.SignupName;
 import io.saim.dash.account.general.repository.SignupNameRepository;
 import io.saim.dash.account.auth.session.SessionManager;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -13,6 +16,7 @@ public class GeneralAccountService {
 
 	private final SignupNameRepository signupNameRepository;
 	private final SessionManager sessionManager;
+	private final PhoneVerificationService phoneVerificationService;
 
 	public GeneralAccountResponseDTO getGeneralAccountDetails(String sessionId) {
 		//세션 ID를 통해 사용자 ID 조회
@@ -31,5 +35,32 @@ public class GeneralAccountService {
 
 		return new GeneralAccountResponseDTO("SUCCESS", "계정 상세 정보를 성공적으로 가져왔습니다.",
 			new GeneralAccountResponseDTO.Data(user.getGeneralName(), email, user.getGeneralPhone()));
+	}
+
+	@Transactional
+	public boolean updatePhoneNumber(String sessionId, GeneralPhoneUpdateDTO updateDTO) {
+		//세션에서 사용자 찾기
+		String userId = sessionManager.getUserIdFromSession(sessionId);
+		if (userId == null) {
+			throw new IllegalArgumentException("유효하지 않은 세션입니다.");
+		}
+
+		SignupName user = signupNameRepository.findById(Long.parseLong(userId))
+			.orElseThrow(() -> new IllegalArgumentException("사용자 정보를 찾을 수 없습니다."));
+
+		String newPhone = updateDTO.getGeneralNewPhone();
+		String verifyCode = updateDTO.getGeneralVerifyCode();
+
+		//새로운 전화번호 인증 확인
+		boolean isVerified = phoneVerificationService.verifyCode(newPhone, verifyCode);
+		if (!isVerified) {
+			return false; //인증 실패 시 변경하지 않음
+		}
+
+		//전화번호 업데이트
+		user.setGeneralPhone(newPhone);
+		signupNameRepository.save(user);
+
+		return true;
 	}
 }

--- a/src/main/java/io/saim/dash/account/general/service/GeneralAccountService.java
+++ b/src/main/java/io/saim/dash/account/general/service/GeneralAccountService.java
@@ -1,0 +1,35 @@
+package io.saim.dash.account.general.service;
+
+import io.saim.dash.account.general.dto.GeneralAccountResponseDTO;
+import io.saim.dash.account.general.model.SignupName;
+import io.saim.dash.account.general.repository.SignupNameRepository;
+import io.saim.dash.account.auth.session.SessionManager;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class GeneralAccountService {
+
+	private final SignupNameRepository signupNameRepository;
+	private final SessionManager sessionManager;
+
+	public GeneralAccountResponseDTO getGeneralAccountDetails(String sessionId) {
+		//세션 ID를 통해 사용자 ID 조회
+		String userId = sessionManager.getUserIdFromSession(sessionId);
+		if (userId == null) {
+			throw new IllegalArgumentException("유효하지 않은 세션입니다.");
+		}
+
+		//사용자 정보 조회
+		SignupName user = signupNameRepository.findById(Long.parseLong(userId))
+			.orElseThrow(() -> new IllegalArgumentException("사용자 정보를 찾을 수 없습니다."));
+
+		//이메일이 없을 경우 "등록된 이메일이 없습니다."로 설정
+		String email = (user.getGeneralEmail() == null || user.getGeneralEmail().isBlank())
+			? "등록된 이메일이 없습니다." : user.getGeneralEmail();
+
+		return new GeneralAccountResponseDTO("SUCCESS", "계정 상세 정보를 성공적으로 가져왔습니다.",
+			new GeneralAccountResponseDTO.Data(user.getGeneralName(), email, user.getGeneralPhone()));
+	}
+}

--- a/src/main/java/io/saim/dash/account/general/service/MyPageService.java
+++ b/src/main/java/io/saim/dash/account/general/service/MyPageService.java
@@ -1,0 +1,38 @@
+package io.saim.dash.account.general.service;
+
+import io.saim.dash.account.auth.session.SessionManager;  // 🔥 auth 패키지의 SessionManager 사용
+import io.saim.dash.account.general.dto.MyPageResponseDTO;
+import io.saim.dash.account.general.model.SignupName;
+import io.saim.dash.account.general.repository.SignupNameRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class MyPageService {
+
+	private final SignupNameRepository signupNameRepository;
+	private final SessionManager sessionManager;
+
+	public MyPageResponseDTO getMyPageInfo(String sessionId) {
+		//세션 유효성 검사
+		if (!sessionManager.isValidSession(sessionId)) {
+			throw new IllegalArgumentException("유효하지 않은 세션 ID입니다.");
+		}
+
+		//세션에서 사용자 ID 가져오기
+		String userId = sessionManager.getUserIdFromSession(sessionId);
+		SignupName user = signupNameRepository.findById(Long.parseLong(userId))
+			.orElseThrow(() -> new IllegalArgumentException("사용자 정보를 찾을 수 없습니다."));
+
+		return new MyPageResponseDTO(
+			"SUCCESS",
+			"계정 정보를 성공적으로 가져왔습니다.",
+			new MyPageResponseDTO.Data(
+				user.getGeneralName(),
+				new MyPageResponseDTO.CouponStatus(1, 0), //예제 값, DB에서 가져오기
+				new MyPageResponseDTO.Menus()
+			)
+		);
+	}
+}

--- a/src/main/java/io/saim/dash/account/general/service/SignupCompleteService.java
+++ b/src/main/java/io/saim/dash/account/general/service/SignupCompleteService.java
@@ -21,7 +21,7 @@ public class SignupCompleteService {
 	public SignupCompleteResponseDTO completeSignup(SignupCompleteRequestDTO requestDTO) {
 		SignupName user = null;
 
-		// 📌 1️⃣ general_id로 기존 사용자 조회 (없으면 예외 발생)
+		//general_id로 기존 사용자 조회 (없으면 예외 발생)
 		if (requestDTO.getGeneralId() != null && !requestDTO.getGeneralId().isBlank()) {
 			user = signupNameRepository.findById(Long.parseLong(requestDTO.getGeneralId()))
 				.orElseThrow(() -> new IllegalArgumentException("존재하지 않는 사용자입니다."));
@@ -29,7 +29,7 @@ public class SignupCompleteService {
 			throw new IllegalArgumentException("general_id가 필요합니다.");
 		}
 
-		// DTO 데이터를 엔티티에 매핑 (널 값 방지)
+		//DTO 데이터를 엔티티에 매핑 (널 값 방지)
 		if (requestDTO.getUserType() != null) user.setGeneralType(requestDTO.getUserType());
 		if (requestDTO.getGeneralName() != null) user.setGeneralName(requestDTO.getGeneralName());
 		if (requestDTO.getGeneralPhone() != null) user.setGeneralPhone(requestDTO.getGeneralPhone());
@@ -37,14 +37,13 @@ public class SignupCompleteService {
 		if (requestDTO.getVendorGroupId() != null) user.setVendorGroupId(requestDTO.getVendorGroupId());
 		if (requestDTO.getDepartmentId() != null) user.setDepartmentId(requestDTO.getDepartmentId());
 
-		// 가입일 자동 설정 (기존 값이 없을 때만)
+		//가입일 자동 설정 (기존 값이 없을 때만)
 		if (user.getJoinedAt() == null) {
 			user.setJoinedAt(LocalDateTime.now());
 		}
 
 		SignupName savedUser = signupNameRepository.save(user);
 
-		// 응답 반환
 		return new SignupCompleteResponseDTO(
 			"SUCCESS",
 			"회원가입이 완료되었습니다.",

--- a/src/main/java/io/saim/dash/account/general/service/SignupNameService.java
+++ b/src/main/java/io/saim/dash/account/general/service/SignupNameService.java
@@ -25,7 +25,7 @@ public class SignupNameService {
 		return signupNameRepository.save(user);
 	}
 
-	// 랜덤한 전화번호를 생성하고 중복 체크 후 반환
+	//랜덤한 전화번호를 생성하고 중복 체크 후 반환
 	private String generateUniquePhone() {
 		Random random = new Random();
 		String phone;

--- a/src/main/java/io/saim/dash/account/general/service/SignupPasswordService.java
+++ b/src/main/java/io/saim/dash/account/general/service/SignupPasswordService.java
@@ -17,7 +17,7 @@ public class SignupPasswordService {
 
 	private final SignupNameRepository signupNameRepository;
 	private final GeneralPasswordRepository passwordRepository;
-	private final PasswordEncoder passwordEncoder; // ✅ SecurityConfig에서 등록된 빈 사용
+	private final PasswordEncoder passwordEncoder;
 
 	@Transactional
 	public GeneralPasswordResponseDTO setPassword(GeneralPasswordRequestDTO requestDto) {
@@ -25,25 +25,24 @@ public class SignupPasswordService {
 		System.out.println("🔹 Password: " + requestDto.getPassword());
 		System.out.println("🔹 Password Confirm: " + requestDto.getPasswordConfirm());
 
-		// 비밀번호 확인 일치 여부 검증
+		//비밀번호 확인 일치 여부 검증
 		if (!requestDto.getPassword().equals(requestDto.getPasswordConfirm())) {
 			throw new IllegalArgumentException("비밀번호가 일치하지 않습니다.");
 		}
 
-		// 사용자 확인 (없으면 예외 발생)
+		//사용자 확인 (없으면 예외 발생)
 		SignupName user = signupNameRepository.findById(requestDto.getGeneralId())
 			.orElseThrow(() -> new IllegalArgumentException("존재하지 않는 사용자입니다."));
 
-		// 기존 비밀번호가 있는지 확인하고 업데이트 처리
+		//기존 비밀번호가 있는지 확인하고 업데이트 처리
 		Password password = passwordRepository.findByUser(user)
 			.orElse(new Password()); // 기존 없으면 새 객체 생성
 
-		// 비밀번호 암호화 후 저장
+		//비밀번호 암호화 후 저장
 		password.setUser(user);
 		password.setHashedPassword(passwordEncoder.encode(requestDto.getPassword()));
 		passwordRepository.save(password);
 
-		// 응답 반환
 		return new GeneralPasswordResponseDTO("SUCCESS", "비밀번호가 설정되었습니다.",
 			new GeneralPasswordResponseDTO.Data(user.getGeneralId()));
 	}

--- a/src/main/java/io/saim/dash/account/general/service/SignupPasswordService.java
+++ b/src/main/java/io/saim/dash/account/general/service/SignupPasswordService.java
@@ -11,6 +11,8 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
+
 @Service
 @RequiredArgsConstructor
 public class SignupPasswordService {
@@ -30,13 +32,15 @@ public class SignupPasswordService {
 			throw new IllegalArgumentException("비밀번호가 일치하지 않습니다.");
 		}
 
-		//사용자 확인 (없으면 예외 발생)
+		//사용자 확인
 		SignupName user = signupNameRepository.findById(requestDto.getGeneralId())
 			.orElseThrow(() -> new IllegalArgumentException("존재하지 않는 사용자입니다."));
 
-		//기존 비밀번호가 있는지 확인하고 업데이트 처리
-		Password password = passwordRepository.findByUser(user)
-			.orElse(new Password()); // 기존 없으면 새 객체 생성
+		//기존 비밀번호가 있는 경우 최신 비밀번호 가져오기
+		List<Password> userPasswords = passwordRepository.findByUser(user);
+		Password password = userPasswords.stream()
+			.max((p1, p2) -> p1.getCreatedAt().compareTo(p2.getCreatedAt())) //최신 비밀번호 찾기
+			.orElse(new Password()); //기존 비밀번호 없으면 새 객체 생성
 
 		//비밀번호 암호화 후 저장
 		password.setUser(user);

--- a/src/main/java/io/saim/dash/common/constants/ValidationMessages.java
+++ b/src/main/java/io/saim/dash/common/constants/ValidationMessages.java
@@ -1,0 +1,7 @@
+package io.saim.dash.common.constants;
+
+public class ValidationMessages {
+	public static final String PHONE_REQUIRED = "전화번호는 필수 입력값입니다.";
+	public static final String PHONE_INVALID_FORMAT = "올바른 전화번호 형식이 아닙니다.";
+	public static final String PASSWORD_REQUIRED = "비밀번호는 필수입니다.";
+}

--- a/src/main/java/io/saim/dash/common/constants/ValidationPatterns.java
+++ b/src/main/java/io/saim/dash/common/constants/ValidationPatterns.java
@@ -1,0 +1,5 @@
+package io.saim.dash.common.constants;
+
+public class ValidationPatterns {
+	public static final String PHONE_REGEX = "^01[0-9]-?\\d{3,4}-?\\d{4}$";
+}

--- a/src/main/java/io/saim/dash/config/SecurityConfig.java
+++ b/src/main/java/io/saim/dash/config/SecurityConfig.java
@@ -18,7 +18,7 @@ public class SecurityConfig {
 			.csrf(csrf -> csrf.disable())
 			.authorizeHttpRequests(auth -> auth
 				.requestMatchers("/", "/public/**", "/auth/google", "/auth/google/callback").permitAll() //OAuth2 관련 허용
-				.requestMatchers("/auth/phone/request", "/auth/phone/verify", "/signup/name", "/signup/password", "/signup/complete", "/auth/login","/auth/password-reset/request", "/auth/password-reset/verify", "/auth/password-reset/complete", "/auth/logout", "/general/mypage", "/general/account").permitAll()
+				.requestMatchers("/auth/phone/request", "/auth/phone/verify", "/signup/name", "/signup/password", "/signup/complete", "/auth/login","/auth/password-reset/request", "/auth/password-reset/verify", "/auth/password-reset/complete", "/auth/logout", "/general/mypage", "/general/account", "/general/account/phone").permitAll()
 				.anyRequest().authenticated()  //그 외 요청은 인증 필요
 			)
 			.oauth2Login(oauth2 -> oauth2

--- a/src/main/java/io/saim/dash/config/SecurityConfig.java
+++ b/src/main/java/io/saim/dash/config/SecurityConfig.java
@@ -18,7 +18,7 @@ public class SecurityConfig {
 			.csrf(csrf -> csrf.disable())
 			.authorizeHttpRequests(auth -> auth
 				.requestMatchers("/", "/public/**", "/auth/google", "/auth/google/callback").permitAll() //OAuth2 관련 허용
-				.requestMatchers("/auth/phone/request", "/auth/phone/verify", "/signup/name", "/signup/password", "/signup/complete", "/auth/login","/auth/password-reset/request", "/auth/password-reset/verify", "/auth/password-reset/complete", "/auth/logout", "/general/mypage", "/general/account", "/general/account/phone", "/general/account/email-verify/request").permitAll()
+				.requestMatchers("/auth/phone/request", "/auth/phone/verify", "/signup/name", "/signup/password", "/signup/complete", "/auth/login","/auth/password-reset/request", "/auth/password-reset/verify", "/auth/password-reset/complete", "/auth/logout", "/general/mypage", "/general/account", "/general/account/phone", "/general/account/email-verify/request", "/general/account/email-verify/confirm").permitAll()
 				.anyRequest().authenticated()  //그 외 요청은 인증 필요
 			)
 			.oauth2Login(oauth2 -> oauth2

--- a/src/main/java/io/saim/dash/config/SecurityConfig.java
+++ b/src/main/java/io/saim/dash/config/SecurityConfig.java
@@ -18,7 +18,7 @@ public class SecurityConfig {
 			.csrf(csrf -> csrf.disable())
 			.authorizeHttpRequests(auth -> auth
 				.requestMatchers("/", "/public/**", "/auth/google", "/auth/google/callback").permitAll() //OAuth2 관련 허용
-				.requestMatchers("/auth/phone/request", "/auth/phone/verify", "/signup/name", "/signup/password", "/signup/complete", "/auth/login","/auth/password-reset/request", "/auth/password-reset/verify").permitAll()
+				.requestMatchers("/auth/phone/request", "/auth/phone/verify", "/signup/name", "/signup/password", "/signup/complete", "/auth/login","/auth/password-reset/request", "/auth/password-reset/verify", "/auth/password-reset/complete").permitAll()
 				.anyRequest().authenticated()  //그 외 요청은 인증 필요
 			)
 			.oauth2Login(oauth2 -> oauth2
@@ -27,7 +27,7 @@ public class SecurityConfig {
 				.failureUrl("/auth/google?error=true") //로그인 실패 시 이동할 경로
 			)
 			.logout(logout -> logout
-				.logoutSuccessUrl("/") // 로그아웃 후 이동할 URL
+				.logoutSuccessUrl("/") //로그아웃 후 이동할 URL
 				.invalidateHttpSession(true)
 				.deleteCookies("JSESSIONID")
 			);

--- a/src/main/java/io/saim/dash/config/SecurityConfig.java
+++ b/src/main/java/io/saim/dash/config/SecurityConfig.java
@@ -18,7 +18,7 @@ public class SecurityConfig {
 			.csrf(csrf -> csrf.disable())
 			.authorizeHttpRequests(auth -> auth
 				.requestMatchers("/", "/public/**", "/auth/google", "/auth/google/callback").permitAll() //OAuth2 관련 허용
-				.requestMatchers("/auth/phone/request", "/auth/phone/verify", "/signup/name", "/signup/password", "/signup/complete", "/auth/login","/auth/password-reset/request", "/auth/password-reset/verify", "/auth/password-reset/complete", "/auth/logout", "/general/mypage", "/general/account", "/general/account/phone", "/general/account/email-verify/request", "/general/account/email-verify/confirm").permitAll()
+				.requestMatchers("/auth/phone/request", "/auth/phone/verify", "/signup/name", "/signup/password", "/signup/complete", "/auth/login","/auth/password-reset/request", "/auth/password-reset/verify", "/auth/password-reset/complete", "/auth/logout", "/general/mypage", "/general/account", "/general/account/phone", "/general/account/email-verify/request", "/general/account/email-verify/confirm", "/general/account/delete").permitAll()
 				.anyRequest().authenticated()  //그 외 요청은 인증 필요
 			)
 			.oauth2Login(oauth2 -> oauth2

--- a/src/main/java/io/saim/dash/config/SecurityConfig.java
+++ b/src/main/java/io/saim/dash/config/SecurityConfig.java
@@ -18,7 +18,7 @@ public class SecurityConfig {
 			.csrf(csrf -> csrf.disable())
 			.authorizeHttpRequests(auth -> auth
 				.requestMatchers("/", "/public/**", "/auth/google", "/auth/google/callback").permitAll() //OAuth2 관련 허용
-				.requestMatchers("/auth/phone/request", "/auth/phone/verify", "/signup/name", "/signup/password", "/signup/complete", "/auth/login","/auth/password-reset/request", "/auth/password-reset/verify", "/auth/password-reset/complete", "/auth/logout", "/general/mypage", "/general/account", "/general/account/phone").permitAll()
+				.requestMatchers("/auth/phone/request", "/auth/phone/verify", "/signup/name", "/signup/password", "/signup/complete", "/auth/login","/auth/password-reset/request", "/auth/password-reset/verify", "/auth/password-reset/complete", "/auth/logout", "/general/mypage", "/general/account", "/general/account/phone", "/general/account/email-verify/request").permitAll()
 				.anyRequest().authenticated()  //그 외 요청은 인증 필요
 			)
 			.oauth2Login(oauth2 -> oauth2

--- a/src/main/java/io/saim/dash/config/SecurityConfig.java
+++ b/src/main/java/io/saim/dash/config/SecurityConfig.java
@@ -18,7 +18,7 @@ public class SecurityConfig {
 			.csrf(csrf -> csrf.disable())
 			.authorizeHttpRequests(auth -> auth
 				.requestMatchers("/", "/public/**", "/auth/google", "/auth/google/callback").permitAll() //OAuth2 관련 허용
-				.requestMatchers("/auth/phone/request", "/auth/phone/verify", "/signup/name", "/signup/password", "/signup/complete", "/auth/login","/auth/password-reset/request", "/auth/password-reset/verify", "/auth/password-reset/complete", "/auth/logout").permitAll()
+				.requestMatchers("/auth/phone/request", "/auth/phone/verify", "/signup/name", "/signup/password", "/signup/complete", "/auth/login","/auth/password-reset/request", "/auth/password-reset/verify", "/auth/password-reset/complete", "/auth/logout", "/general/mypage").permitAll()
 				.anyRequest().authenticated()  //그 외 요청은 인증 필요
 			)
 			.oauth2Login(oauth2 -> oauth2

--- a/src/main/java/io/saim/dash/config/SecurityConfig.java
+++ b/src/main/java/io/saim/dash/config/SecurityConfig.java
@@ -18,7 +18,7 @@ public class SecurityConfig {
 			.csrf(csrf -> csrf.disable())
 			.authorizeHttpRequests(auth -> auth
 				.requestMatchers("/", "/public/**", "/auth/google", "/auth/google/callback").permitAll() //OAuth2 관련 허용
-				.requestMatchers("/auth/phone/request", "/auth/phone/verify", "/signup/name", "/signup/password", "/signup/complete", "/auth/login","/auth/password-reset/request", "/auth/password-reset/verify", "/auth/password-reset/complete", "/auth/logout", "/general/mypage").permitAll()
+				.requestMatchers("/auth/phone/request", "/auth/phone/verify", "/signup/name", "/signup/password", "/signup/complete", "/auth/login","/auth/password-reset/request", "/auth/password-reset/verify", "/auth/password-reset/complete", "/auth/logout", "/general/mypage", "/general/account").permitAll()
 				.anyRequest().authenticated()  //그 외 요청은 인증 필요
 			)
 			.oauth2Login(oauth2 -> oauth2

--- a/src/main/java/io/saim/dash/config/SecurityConfig.java
+++ b/src/main/java/io/saim/dash/config/SecurityConfig.java
@@ -18,7 +18,7 @@ public class SecurityConfig {
 			.csrf(csrf -> csrf.disable())
 			.authorizeHttpRequests(auth -> auth
 				.requestMatchers("/", "/public/**", "/auth/google", "/auth/google/callback").permitAll() //OAuth2 관련 허용
-				.requestMatchers("/auth/phone/request", "/auth/phone/verify", "/signup/name", "/signup/password", "/signup/complete", "/auth/login","/auth/password-reset/request", "/auth/password-reset/verify", "/auth/password-reset/complete").permitAll()
+				.requestMatchers("/auth/phone/request", "/auth/phone/verify", "/signup/name", "/signup/password", "/signup/complete", "/auth/login","/auth/password-reset/request", "/auth/password-reset/verify", "/auth/password-reset/complete", "/auth/logout").permitAll()
 				.anyRequest().authenticated()  //그 외 요청은 인증 필요
 			)
 			.oauth2Login(oauth2 -> oauth2

--- a/src/main/java/io/saim/dash/global/dto/APIStatus.java
+++ b/src/main/java/io/saim/dash/global/dto/APIStatus.java
@@ -1,5 +1,5 @@
 package io.saim.dash.global.dto;
 
 public enum APIStatus {
-	SUCCEED, FAILED
+	SUCCESS, FAILURE
 }

--- a/src/test/java/io/saim/dash/account/auth/service/LogoutServiceTest.java
+++ b/src/test/java/io/saim/dash/account/auth/service/LogoutServiceTest.java
@@ -1,0 +1,53 @@
+package io.saim.dash.account.auth.service;
+
+import io.saim.dash.account.auth.session.SessionManager;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+class LogoutServiceTest {
+
+	private SessionManager sessionManager;
+	private LogoutService logoutService;
+
+	@BeforeEach
+	void setUp() {
+		//세션 매니저를 Mock 객체로 생성
+		sessionManager = mock(SessionManager.class);
+		//Mock된 세션 매니저를 사용하여 LogoutService 초기화
+		logoutService = new LogoutService(sessionManager);
+	}
+
+	@Test
+	void testInvalidateSession_Success() {
+		String sessionId = "valid-session-id";
+
+		//유효한 세션 ID가 존재한다고 가정
+		when(sessionManager.isValidSession(sessionId)).thenReturn(true);
+
+		//로그아웃 실행
+		boolean result = logoutService.invalidateSession(sessionId);
+
+		//로그아웃이 성공해야 함
+		assertTrue(result);
+		//세션이 정확히 1번 삭제되었는지 확인
+		verify(sessionManager, times(1)).invalidateSession(sessionId);
+	}
+
+	@Test
+	void testInvalidateSession_Failure() {
+		String sessionId = "invalid-session-id";
+
+		//유효하지 않은 세션 ID라고 가정
+		when(sessionManager.isValidSession(sessionId)).thenReturn(false);
+
+		//로그아웃 실행
+		boolean result = logoutService.invalidateSession(sessionId);
+
+		//로그아웃이 실패해야 함
+		assertFalse(result);
+		//세션 삭제 메서드가 호출되지 않았는지 확인
+		verify(sessionManager, never()).invalidateSession(sessionId);
+	}
+}


### PR DESCRIPTION
## 🌲 작업한 브랜치
- dev/ysbeam

## 📚 작업한 내용
- 비밀번호 재설정(새 비밀번호 입력)
- 로그인, 로그아웃 기능
- 일반사용자 계정 조회, 계정 상세 조회 기능
- 일반사용자 계정 수정 기능(전화번호 변경) 개발
- 이메일 변경 인증 요청 기능
- 이메일 변경 인증 코드 확인 기능
- 일반 사용자 회원 탈퇴 기능

## ❗이슈 사항
- 유닛 테스트는 추후에 추가해두도록 하겠습니답

## 🤔 궁금한 점